### PR TITLE
Escape all literal dollar signs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu 20.04
+        os: ubuntu-latest
     runs-on: ${{ matrix.os }}
     if: github.event.pull_request.draft == false
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,15 +27,17 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Running Tests
         run: |
-          sudo touch /.githubenv
-          (cd libdash; python setup.py install)
           pip install .
-          (cd tests; make test)
-          timer=$(LANG=en_us_88591; date)
-          echo "VERSION<<EOF" >> $GITHUB_ENV
-          echo "OS:${{matrix.os}}" >> $GITHUB_ENV
-          echo "$timer" >> $GITHUB_ENV
-          # Parse the results and construct a github message post
-          # we append the data to the global env
-          cat results.log >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
+
+          cd tests;
+          make test
+          test_succ=$?
+
+          timer="$(LANG=en_us_88591; date)"
+          echo "VERSION<<EOF" >> "$GITHUB_ENV"
+          echo "OS:${{matrix.os}}" >> "$GITHUB_ENV"
+          echo "$timer" >> "$GITHUB_ENV"
+          cat python.log >> "$GITHUB_ENV"
+          echo 'EOF' >> "$GITHUB_ENV"
+
+          exit $test_succ

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ubuntu-latest
+        os:
+          - ubuntu-latest
     runs-on: ${{ matrix.os }}
     if: github.event.pull_request.draft == false
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Running Tests
         run: |
-          pip install .
-
           cd tests;
           make test
           test_succ=$?

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,6 @@ on:
   pull_request_target:
     types: [assigned, opened, synchronize, reopened, ready_for_review]
     paths: 
-        - libdash/**
         - shasta/**
   push:
     branches:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Running Tests
         run: |
           cd tests;
+          ./setup_test.sh
           make test
           test_succ=$?
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,41 @@
+name: Test
+on: 
+  pull_request_target:
+    types: [assigned, opened, synchronize, reopened, ready_for_review]
+    paths: 
+        - libdash/**
+        - shasta/**
+  push:
+    branches:
+      - main
+      - future
+    paths: 
+      - libdash/**
+      - shasta/**
+jobs:
+  Shasta-Test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu 20.04
+    runs-on: ${{ matrix.os }}
+    if: github.event.pull_request.draft == false
+    steps:
+      - uses: actions/checkout@v2 
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Running Tests
+        run: |
+          sudo touch /.githubenv
+          (cd libdash; python setup.py install)
+          pip install .
+          (cd tests; make test)
+          timer=$(LANG=en_us_88591; date)
+          echo "VERSION<<EOF" >> $GITHUB_ENV
+          echo "OS:${{matrix.os}}" >> $GITHUB_ENV
+          echo "$timer" >> $GITHUB_ENV
+          # Parse the results and construct a github message post
+          # we append the data to the global env
+          cat results.log >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *__pycache__*
 dist/*
 shasta.egg-info/*
+tests/libdash_tests/
+tests/*.log

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libdash"]
+	path = libdash
+	url = git@github.com:binpash/libdash.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "libdash"]
-	path = libdash
-	url = git@github.com:binpash/libdash.git

--- a/shasta/ast_node.py
+++ b/shasta/ast_node.py
@@ -795,7 +795,8 @@ def string_of_arg(args, quote_mode=UNQUOTED):
     text = []
     while i < len(args):
         c = args[i].pretty(quote_mode=quote_mode)
-        if c == "$" and (i+1 < len(args)) and isinstance(args[i+1],EArgChar):
+        # escape dollar signs to avoid variable interpolation
+        if c == "$":
             c = "\\$"
         text.append(c)
 

--- a/shasta/ast_node.py
+++ b/shasta/ast_node.py
@@ -796,7 +796,7 @@ def string_of_arg(args, quote_mode=UNQUOTED):
     while i < len(args):
         c = args[i].pretty(quote_mode=quote_mode)
         # escape dollar signs to avoid variable interpolation
-        if c == "$":
+        if c == "$" and i + 1 < len(args):
             c = "\\$"
         text.append(c)
 

--- a/tests/LICENSE
+++ b/tests/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Michael Greenberg, Konstantinos Kallas, Thurston Dang, and Bolun Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,6 +1,6 @@
-.PHONY: test clean
+.PHONY: setup_test test clean
 
-test: rt.py ../shasta/*.py libdash_tests
+test: rt.py ../shasta/*.py libdash_tests setup_test
 	@find libdash_tests/tests libdash_tests/pash_tests -type f | while read f; do libdash_tests/round_trip.sh ./rt.py "$$f"; done | tee python.log
 	@cat python.log | egrep '^[A-Z0-9_]+:' | cut -d ':' -f 1 | sort | uniq -c
 	@grep ':' python.log && echo "FAILED" && exit 1 || exit 0
@@ -9,6 +9,9 @@ libdash_tests:
 	git clone https://github.com/binpash/libdash.git
 	mv libdash/test libdash_tests
 	rm -rf libdash
+
+setup_test:
+	pip install .. libdash
 
 clean:
 	rm -rf $(wildcard *.log) libdash_tests

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -11,4 +11,4 @@ libdash_tests:
 	rm -rf libdash
 
 clean:
-	rm -f $(wildcard *.log)
+	rm -rf $(wildcard *.log) libdash_tests

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,17 +1,9 @@
 .PHONY: setup_test test clean
 
-test: rt.py ../shasta/*.py libdash_tests setup_test
+test: rt.py ../shasta/*.py
 	@find libdash_tests/tests libdash_tests/pash_tests -type f | while read f; do libdash_tests/round_trip.sh ./rt.py "$$f"; done | tee python.log
 	@cat python.log | egrep '^[A-Z0-9_]+:' | cut -d ':' -f 1 | sort | uniq -c
 	@grep ':' python.log && echo "FAILED" && exit 1 || exit 0
-
-libdash_tests:
-	git clone https://github.com/binpash/libdash.git
-	mv libdash/test libdash_tests
-	rm -rf libdash
-
-setup_test:
-	pip install .. libdash
 
 clean:
 	rm -rf $(wildcard *.log) libdash_tests

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,9 @@
+.PHONY:  test clean
+
+test: rt.py ../shasta/*.py
+	@find ../libdash/test/tests ../libdash/test/pash_tests -type f | while read f; do ../libdash/test/round_trip.sh ./rt.py "$$f"; done | tee python.log
+	@cat python.log | egrep '^[A-Z0-9_]+:' | cut -d ':' -f 1 | sort | uniq -c
+	@grep ':' python.log && echo "FAILED" && exit 1 || exit 0
+
+clean:
+	rm *.o *.so *.log

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,9 +1,14 @@
-.PHONY:  test clean
+.PHONY: test clean
 
-test: rt.py ../shasta/*.py
-	@find ../libdash/test/tests ../libdash/test/pash_tests -type f | while read f; do ../libdash/test/round_trip.sh ./rt.py "$$f"; done | tee python.log
+test: rt.py ../shasta/*.py libdash_tests
+	@find libdash_tests/tests libdash_tests/pash_tests -type f | while read f; do libdash_tests/round_trip.sh ./rt.py "$$f"; done | tee python.log
 	@cat python.log | egrep '^[A-Z0-9_]+:' | cut -d ':' -f 1 | sort | uniq -c
 	@grep ':' python.log && echo "FAILED" && exit 1 || exit 0
 
+libdash_tests:
+	git clone https://github.com/binpash/libdash.git
+	mv libdash/test libdash_tests
+	rm -rf libdash
+
 clean:
-	rm *.o *.so *.log
+	rm -f $(wildcard *.log)

--- a/tests/rt.py
+++ b/tests/rt.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+import sys
+
+import libdash
+from shasta.json_to_ast import to_ast_node
+
+
+sys.setrecursionlimit (9001)
+
+def print_asts(new_asts):
+    for (ast, lines, linno_before, linno_after) in new_asts:
+        print(to_ast_node(ast).pretty())
+
+if (len(sys.argv) == 1):
+    new_asts = libdash.parse("-", True)
+else:
+    new_asts = libdash.parse(sys.argv[1], True)
+    
+print_asts(new_asts)

--- a/tests/setup_test.sh
+++ b/tests/setup_test.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ ! -d libdash_tests/ ]; then
+  git clone https://github.com/binpash/libdash.git
+  mv libdash/test libdash_tests
+  rm -rf libdash
+fi
+
+pip install .. libdash


### PR DESCRIPTION
In principle, should resolve binpash/PaSh#664. If `c` is a literal dollar sign, it should be parsed as one (with no need to account for escaping & variable interpolation). Yet, this fix is suspiciously simple — is there an edge case here?

The tests for PaSh still pass with this change.