### PR TITLE
Correctly print subshells nested in a variable expansion 

### DIFF
--- a/shasta/ast_node.py
+++ b/shasta/ast_node.py
@@ -726,7 +726,14 @@ class BArgChar(ArgChar):
     
     def pretty(self, quote_mode=UNQUOTED):
         param = self.node
-        return "$(" + param.pretty() + ")"
+        body = param.pretty()
+        # to handle $( () )
+        try:
+            if body[0] == "(" and body[-1] == ")":
+                body = f" {body} "
+        except IndexError:
+            pass
+        return "$(" + body + ")"
 
 class AssignNode(AstNode):
     var: str


### PR DESCRIPTION
Before, shasta was printing expressions like `abc=$( (echo abc) )` as `abc=$((echo abc))`, an arithmetic substitution. Same as libdash/#32, where a libdash/shasta test was added.

Triggered in the coreutils configure script (see binpash/pash#573).